### PR TITLE
Implement order API

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -1,0 +1,34 @@
+const asyncHandler = require('express-async-handler');
+const Order = require('../models/orderModel');
+const Mod = require('../models/modModel');
+
+// @desc    Create new order
+// @route   POST /api/orders
+// @access  Private
+const createOrder = asyncHandler(async (req, res) => {
+  const { orderItems, totalAmount } = req.body;
+
+  if (!orderItems || orderItems.length === 0) {
+    res.status(400);
+    throw new Error('No order items');
+  }
+
+  const order = new Order({
+    user: req.user._id, // From 'protect' middleware
+    items: orderItems,
+    totalAmount,
+  });
+
+  const createdOrder = await order.save();
+  res.status(201).json(createdOrder);
+});
+
+// @desc    Get logged in user's orders
+// @route   GET /api/orders/my-history
+// @access  Private
+const getMyOrders = asyncHandler(async (req, res) => {
+  const orders = await Order.find({ user: req.user._id }).populate('items.mod', 'name images');
+  res.json(orders);
+});
+
+module.exports = { createOrder, getMyOrders };

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { createOrder, getMyOrders } = require('../controllers/orderController');
+const { protect } = require('../middleware/authMiddleware');
+
+// Both routes are protected and require a valid user token
+router.route('/').post(protect, createOrder);
+router.route('/my-history').get(protect, getMyOrders);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+// Other required imports would go here
+const modRoutes = require('./routes/modRoutes');
+const orderRoutes = require('./routes/orderRoutes');
+
+const app = express();
+app.use(express.json());
+
+// Mount existing routes
+app.use('/api/mods', modRoutes);
+app.use('/api/orders', orderRoutes);
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add API controller logic for creating and fetching orders
- define express routes for order endpoints
- hook up order routes in `server.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ccfb8ba688322982a3f77e4014ec7