### PR TITLE
Add Express mod CRUD API

### DIFF
--- a/controllers/modController.js
+++ b/controllers/modController.js
@@ -1,0 +1,97 @@
+const Mod = require('../models/modModel');
+
+// @desc    Fetch all mods with optional filters
+// @route   GET /api/mods
+// @access  Public
+const getAllMods = async (req, res) => {
+  try {
+    const { category, tags } = req.query;
+    const filter = {};
+    if (category) filter.category = category;
+    if (tags) {
+      const tagsArray = tags.split(',').map(tag => tag.trim());
+      filter.tags = { $in: tagsArray };
+    }
+
+    const mods = await Mod.find(filter);
+    res.json(mods);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server Error' });
+  }
+};
+
+// @desc    Get mod by ID
+// @route   GET /api/mods/:id
+// @access  Public
+const getModById = async (req, res) => {
+  try {
+    const mod = await Mod.findById(req.params.id);
+    if (!mod) {
+      return res.status(404).json({ message: 'Mod not found' });
+    }
+    res.json(mod);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server Error' });
+  }
+};
+
+// @desc    Create a mod
+// @route   POST /api/mods
+// @access  Admin
+const createMod = async (req, res) => {
+  try {
+    const mod = new Mod(req.body);
+    const createdMod = await mod.save();
+    res.status(201).json(createdMod);
+  } catch (error) {
+    console.error(error);
+    res.status(400).json({ message: 'Invalid mod data' });
+  }
+};
+
+// @desc    Update a mod
+// @route   PUT /api/mods/:id
+// @access  Admin
+const updateMod = async (req, res) => {
+  try {
+    const mod = await Mod.findById(req.params.id);
+    if (!mod) {
+      return res.status(404).json({ message: 'Mod not found' });
+    }
+
+    Object.assign(mod, req.body);
+    const updatedMod = await mod.save();
+    res.json(updatedMod);
+  } catch (error) {
+    console.error(error);
+    res.status(400).json({ message: 'Invalid mod data' });
+  }
+};
+
+// @desc    Delete a mod
+// @route   DELETE /api/mods/:id
+// @access  Admin
+const deleteMod = async (req, res) => {
+  try {
+    const mod = await Mod.findById(req.params.id);
+    if (!mod) {
+      return res.status(404).json({ message: 'Mod not found' });
+    }
+
+    await mod.deleteOne();
+    res.json({ message: 'Mod removed' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server Error' });
+  }
+};
+
+module.exports = {
+  getAllMods,
+  getModById,
+  createMod,
+  updateMod,
+  deleteMod,
+};

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,0 +1,17 @@
+// Placeholder authentication middleware
+
+const protect = (req, res, next) => {
+  // In a real app, verify user authentication here
+  req.user = { id: 'user1', isAdmin: false };
+  next();
+};
+
+const admin = (req, res, next) => {
+  if (req.user && req.user.isAdmin) {
+    next();
+  } else {
+    res.status(401).json({ message: 'Not authorized as admin' });
+  }
+};
+
+module.exports = { protect, admin };

--- a/models/modModel.js
+++ b/models/modModel.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const modSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  description: { type: String },
+  category: { type: String },
+  tags: [{ type: String }],
+  price: { type: Number },
+  rating: { type: Number },
+  reviewCount: { type: Number },
+  images: [{ type: String }],
+  creator: { type: String },
+  downloadSize: { type: String },
+  lastUpdated: { type: Date },
+  downloads: { type: Number },
+}, {
+  timestamps: true,
+});
+
+module.exports = mongoose.model('Mod', modSchema);

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
     "dotenv": "^16.0.1",
+    "express": "^4.18.2",
     "framer-motion": "^10.16.4",
     "lucide-react": "^0.484.0",
+    "mongoose": "^7.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
@@ -30,7 +32,8 @@
   "scripts": {
     "start": "vite",
     "build": "vite build --sourcemap",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "server": "node server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/routes/modRoutes.js
+++ b/routes/modRoutes.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getAllMods,
+  getModById,
+  createMod,
+  updateMod,
+  deleteMod,
+} = require('../controllers/modController');
+const { protect, admin } = require('../middleware/authMiddleware');
+
+router.route('/')
+  .get(getAllMods)
+  .post(protect, admin, createMod);
+
+router.route('/:id')
+  .get(getModById)
+  .put(protect, admin, updateMod)
+  .delete(protect, admin, deleteMod);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+const modRoutes = require('./routes/modRoutes');
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+app.use('/api/mods', modRoutes);
+
+const PORT = process.env.PORT || 5000;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/mods';
+
+mongoose.connect(MONGO_URI)
+  .then(() => {
+    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  })
+  .catch(err => {
+    console.error('Mongo connection error', err);
+  });


### PR DESCRIPTION
## Summary
- create Mod model, controller, and routes for CRUD operations
- add placeholder auth middleware
- bootstrap Express server with Mongo connection
- add express and mongoose dependencies

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccf28c9808322b8962185b3661c52