### PR TITLE
Add server-side auth basics

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,0 +1,25 @@
+const asyncHandler = require('express-async-handler');
+const jwt = require('jsonwebtoken');
+const User = require('../models/userModel');
+
+const generateToken = (id) => {
+  return jwt.sign({ id }, process.env.JWT_SECRET, { expiresIn: '30d' });
+};
+
+const loginOrRegister = asyncHandler(async (req, res) => {
+  const { telegramId, username } = req.body;
+  let user = await User.findOne({ telegramId });
+
+  if (!user) {
+    user = await User.create({ telegramId, username });
+  }
+
+  res.json({
+    _id: user._id,
+    telegramId: user.telegramId,
+    username: user.username,
+    token: generateToken(user._id),
+  });
+});
+
+module.exports = { loginOrRegister };

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,0 +1,33 @@
+const jwt = require('jsonwebtoken');
+const asyncHandler = require('express-async-handler');
+const User = require('../models/userModel');
+
+const protect = asyncHandler(async (req, res, next) => {
+  let token;
+  if (req.headers.authorization && req.headers.authorization.startsWith('Bearer')) {
+    try {
+      token = req.headers.authorization.split(' ')[1];
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      req.user = await User.findById(decoded.id).select('-password');
+      next();
+    } catch (error) {
+      res.status(401);
+      throw new Error('Not authorized, token failed');
+    }
+  }
+  if (!token) {
+    res.status(401);
+    throw new Error('Not authorized, no token');
+  }
+});
+
+const admin = (req, res, next) => {
+  if (req.user && req.user.role === 'admin') {
+    next();
+  } else {
+    res.status(401);
+    throw new Error('Not authorized as an admin');
+  }
+};
+
+module.exports = { protect, admin };

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { loginOrRegister } = require('../controllers/authController');
+const router = express.Router();
+
+router.post('/telegram', loginOrRegister);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create auth controller for login/registration
- set up authentication routes
- add middleware to protect endpoints

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ccf1a00588322a58523ca707f32d3